### PR TITLE
Ensure wizard messages go to private chat vs. room

### DIFF
--- a/lib/lita/wizard.rb
+++ b/lib/lita/wizard.rb
@@ -148,7 +148,8 @@ class Lita::Wizard
   end
 
   def send_message(body)
-    message.reply body
+    # Wizard must run in a private chat versus a room
+    message.reply_privately body
   end
 
   class << self


### PR DESCRIPTION
From what I could tell when using lita-standup, it is important that the wizard based commands are handled via private chat and do not take place in rooms. This change ensures that all wizard responses happen in a private chat with the initiating user and do not start in a channel, even if that is where the request came from.